### PR TITLE
Removed need to activate the virtualenv prior to running "make test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ test: $(VENV) $(TARBALL_NAME) ## Run Sanity Tests
 	cd ./ansible_collections/cisco/cml && git init .
 	$(VENV_BIN)/pip uninstall -y ansible-base
 	$(VENV_BIN)/pip install https://github.com/ansible/ansible/archive/stable-2.10.tar.gz --disable-pip-version-check
-	cd ./ansible_collections/cisco/cml && ansible-test sanity --docker -v --color
+	cd ./ansible_collections/cisco/cml && ../../../$(VENV_BIN)/ansible-test sanity --docker -v --color
 	$(VENV_BIN)/pip uninstall -y ansible-base
 	$(VENV_BIN)/pip install https://github.com/ansible/ansible/archive/stable-2.11.tar.gz --disable-pip-version-check
-	cd ./ansible_collections/cisco/cml && ansible-test sanity --docker -v --color
+	cd ./ansible_collections/cisco/cml && ../../../$(VENV_BIN)/ansible-test sanity --docker -v --color
 	$(VENV_BIN)/pip uninstall -y ansible-base
 	$(VENV_BIN)/pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
-	cd ./ansible_collections/cisco/cml && ansible-test sanity --docker -v --color
+	cd ./ansible_collections/cisco/cml && ../../../$(VENV_BIN)/ansible-test sanity --docker -v --color
 	$(RM) -r ./ansible_collections
 
 clean: ## Clean


### PR DESCRIPTION
When executing tests locally prior to this change, it was necessary to activate the virtualenv before running `make test`.  This PR updates the Makefile to use the relative path to ansible-test in the virtualenv.  So to test your changes before commit:
```
make clean
make build
make test
```