### PR TITLE
Add a topology yaml object to cml_lab_facts

### DIFF
--- a/plugins/modules/cml_lab_facts.py
+++ b/plugins/modules/cml_lab_facts.py
@@ -63,6 +63,7 @@ EXAMPLES = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.cml.plugins.module_utils.cml_utils import cmlModule, cml_argument_spec
+import yaml
 
 
 def run_module():
@@ -86,6 +87,8 @@ def run_module():
         # to handle duplicates
         lab = labs[0]
         lab.sync()
+        topology = lab.download()
+        cml_facts['topology'] = yaml.safe_load(topology)
         cml_facts['details'] = lab.details()
         cml_facts['nodes'] = {}
         for node in lab.nodes():


### PR DESCRIPTION
 updated cml_lab_facts to include a topology key with a cml deployable #topology yaml object

#36 