### PR TITLE
Add CML_LAB env var fallback to cml_lab_facts module

### DIFF
--- a/plugins/modules/cml_lab_facts.py
+++ b/plugins/modules/cml_lab_facts.py
@@ -68,7 +68,7 @@ from ansible_collections.cisco.cml.plugins.module_utils.cml_utils import cmlModu
 def run_module():
     # define available arguments/parameters a user can pass to the module
     argument_spec = cml_argument_spec()
-    argument_spec.update(lab=dict(type='str', required=True), )
+    argument_spec.update(lab=dict(type='str', required=True, fallback=(env_fallback, ['CML_LAB'])), )
 
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the

--- a/plugins/modules/cml_lab_facts.py
+++ b/plugins/modules/cml_lab_facts.py
@@ -61,7 +61,7 @@ EXAMPLES = r"""
         var: results
 """
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.cisco.cml.plugins.module_utils.cml_utils import cmlModule, cml_argument_spec
 
 


### PR DESCRIPTION
Fix inconsistency between modules explained in issue #40 so all relevant modules use the ENV var CML_LAB if used and if param "lab" is not provided.