### PR TITLE
check_mode support for cml_lab and cml_node modules

### DIFF
--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -138,7 +138,7 @@ def run_module():
     if cml.params['state'] in ['present', 'started']:
         if lab is None:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             # create the lab
             if cml.params['topology']:
                 lab = cml.client.import_lab(cml.params['topology'], title=cml.params['lab'])
@@ -157,14 +157,14 @@ def run_module():
             cml.result['changed'] = True
         elif lab.state() == "STOPPED" and cml.params['state'] == 'started':
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             # start existing stopped lab
             lab.start(wait=cml.params['wait'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'absent':
         if lab:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             # remove existing lab
             cml.result['changed'] = True
             if lab.state() == "STARTED":
@@ -177,7 +177,7 @@ def run_module():
         if lab:
             if lab.state() == "STARTED":
                 if module.check_mode:
-                    module.exit_json(changed=True)
+                    cml.exit_json(changed=True)
                 # stop existing running lab
                 cml.result['changed'] = True
                 lab.stop(wait=True)
@@ -185,7 +185,7 @@ def run_module():
         if lab:
             if lab.state() == "STOPPED":
                 if module.check_mode:
-                    module.exit_json(changed=True)
+                    cml.exit_json(changed=True)
                 # wipe existing stopped lab
                 cml.result['changed'] = True
                 lab.wipe(wait=True)

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -137,6 +137,8 @@ def run_module():
 
     if cml.params['state'] in ['present', 'started']:
         if lab is None:
+            if module.check_mode:
+                module.exit_json(changed=True)
             # create the lab
             if cml.params['topology']:
                 lab = cml.client.import_lab(cml.params['topology'], title=cml.params['lab'])
@@ -154,11 +156,15 @@ def run_module():
             lab.title = cml.params['lab']
             cml.result['changed'] = True
         elif lab.state() == "STOPPED" and cml.params['state'] == 'started':
+            if module.check_mode:
+                module.exit_json(changed=True)
             # start existing stopped lab
             lab.start(wait=cml.params['wait'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'absent':
         if lab:
+            if module.check_mode:
+                module.exit_json(changed=True)
             # remove existing lab
             cml.result['changed'] = True
             if lab.state() == "STARTED":
@@ -170,12 +176,16 @@ def run_module():
     elif cml.params['state'] == 'stopped':
         if lab:
             if lab.state() == "STARTED":
+                if module.check_mode:
+                    module.exit_json(changed=True)
                 # stop existing running lab
                 cml.result['changed'] = True
                 lab.stop(wait=True)
     elif cml.params['state'] == 'wiped':
         if lab:
             if lab.state() == "STOPPED":
+                if module.check_mode:
+                    module.exit_json(changed=True)
                 # wipe existing stopped lab
                 cml.result['changed'] = True
                 lab.wipe(wait=True)

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -137,8 +137,9 @@ def run_module():
 
     if cml.params['state'] in ['present', 'started']:
         if lab is None:
+            cml.result['changed'] = True
             if module.check_mode:
-                cml.exit_json(changed=True)
+                cml.exit_json()
             # create the lab
             if cml.params['topology']:
                 lab = cml.client.import_lab(cml.params['topology'], title=cml.params['lab'])
@@ -154,19 +155,18 @@ def run_module():
             if cml.params['state'] == 'started':
                 lab.start(wait=cml.params['wait'])
             lab.title = cml.params['lab']
-            cml.result['changed'] = True
         elif lab.state() == "STOPPED" and cml.params['state'] == 'started':
+            cml.result['changed'] = True
             if module.check_mode:
-                cml.exit_json(changed=True)
+                cml.exit_json()
             # start existing stopped lab
             lab.start(wait=cml.params['wait'])
-            cml.result['changed'] = True
     elif cml.params['state'] == 'absent':
         if lab:
-            if module.check_mode:
-                cml.exit_json(changed=True)
-            # remove existing lab
             cml.result['changed'] = True
+            if module.check_mode:
+                cml.exit_json()
+            # remove existing lab
             if lab.state() == "STARTED":
                 lab.stop(wait=True)
                 lab.wipe(wait=True)
@@ -176,16 +176,17 @@ def run_module():
     elif cml.params['state'] == 'stopped':
         if lab:
             if lab.state() == "STARTED":
-                if module.check_mode:
-                    cml.exit_json(changed=True)
-                # stop existing running lab
                 cml.result['changed'] = True
+                if module.check_mode:
+                    cml.exit_json()
+                # stop existing running lab
                 lab.stop(wait=True)
     elif cml.params['state'] == 'wiped':
         if lab:
             if lab.state() == "STOPPED":
+                cml.result['changed'] = True
                 if module.check_mode:
-                    cml.exit_json(changed=True)
+                    cml.exit_json()
                 # wipe existing stopped lab
                 cml.result['changed'] = True
                 lab.wipe(wait=True)

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -153,12 +153,16 @@ def run_module():
     node = cml.get_node_by_name(lab, cml.params['name'])
     if cml.params['state'] == 'present':
         if node is None:
+            if module.check_mode:
+                module.exit_json(changed=True)
             node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'started':
         if node is None:
             cml.fail_json("Node must be created before it is started")
         if node.state not in ['STARTED', 'BOOTED']:
+            if module.check_mode:
+                module.exit_json(changed=True)
             if node.state == 'DEFINED_ON_CORE' and cml.params['config']:
                 node.config = cml.params['config']
             if cml.params['image_definition']:
@@ -171,6 +175,8 @@ def run_module():
         if node is None:
             cml.fail_json("Node must be created before it is stopped")
         if node.state not in ['STOPPED', 'DEFINED_ON_CORE']:
+            if module.check_mode:
+                module.exit_json(changed=True)
             if cml.params['wait'] is False:
                 lab.wait_for_covergence = False
             node.stop()
@@ -179,6 +185,8 @@ def run_module():
         if node is None:
             cml.fail_json("Node must be created before it is wiped")
         if node.state not in ['DEFINED_ON_CORE']:
+            if module.check_mode:
+                module.exit_json(changed=True)
             node.wipe(wait=cml.params['wait'])
             cml.result['changed'] = True
     cml.exit_json(**cml.result)

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -154,7 +154,7 @@ def run_module():
     if cml.params['state'] == 'present':
         if node is None:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'started':
@@ -162,7 +162,7 @@ def run_module():
             cml.fail_json("Node must be created before it is started")
         if node.state not in ['STARTED', 'BOOTED']:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             if node.state == 'DEFINED_ON_CORE' and cml.params['config']:
                 node.config = cml.params['config']
             if cml.params['image_definition']:
@@ -176,7 +176,7 @@ def run_module():
             cml.fail_json("Node must be created before it is stopped")
         if node.state not in ['STOPPED', 'DEFINED_ON_CORE']:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             if cml.params['wait'] is False:
                 lab.wait_for_covergence = False
             node.stop()
@@ -186,7 +186,7 @@ def run_module():
             cml.fail_json("Node must be created before it is wiped")
         if node.state not in ['DEFINED_ON_CORE']:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             node.wipe(wait=cml.params['wait'])
             cml.result['changed'] = True
     cml.exit_json(**cml.result)

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -153,16 +153,17 @@ def run_module():
     node = cml.get_node_by_name(lab, cml.params['name'])
     if cml.params['state'] == 'present':
         if node is None:
-            if module.check_mode:
-                cml.exit_json(changed=True)
-            node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
             cml.result['changed'] = True
+            if module.check_mode:
+                cml.exit_json()
+            node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
     elif cml.params['state'] == 'started':
         if node is None:
             cml.fail_json("Node must be created before it is started")
         if node.state not in ['STARTED', 'BOOTED']:
+            cml.result['changed'] = True
             if module.check_mode:
-                cml.exit_json(changed=True)
+                cml.exit_json()
             if node.state == 'DEFINED_ON_CORE' and cml.params['config']:
                 node.config = cml.params['config']
             if cml.params['image_definition']:
@@ -170,25 +171,24 @@ def run_module():
             if cml.params['wait'] is False:
                 lab.wait_for_covergence = False
             node.start()
-            cml.result['changed'] = True
     elif cml.params['state'] == 'stopped':
         if node is None:
             cml.fail_json("Node must be created before it is stopped")
         if node.state not in ['STOPPED', 'DEFINED_ON_CORE']:
+            cml.result['changed'] = True
             if module.check_mode:
-                cml.exit_json(changed=True)
+                cml.exit_json()
             if cml.params['wait'] is False:
                 lab.wait_for_covergence = False
             node.stop()
-            cml.result['changed'] = True
     elif cml.params['state'] == 'wiped':
         if node is None:
             cml.fail_json("Node must be created before it is wiped")
         if node.state not in ['DEFINED_ON_CORE']:
-            if module.check_mode:
-                cml.exit_json(changed=True)
-            node.wipe(wait=cml.params['wait'])
             cml.result['changed'] = True
+            if module.check_mode:
+                cml.exit_json()
+            node.wipe(wait=cml.params['wait'])
     cml.exit_json(**cml.result)
 
 

--- a/plugins/modules/cml_users.py
+++ b/plugins/modules/cml_users.py
@@ -159,7 +159,7 @@ def run_module():
     if cml.params['state'] == 'present':
         if userid is None:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             module.debug('Create user %s' % cml.params['name'])
             try:
                 cml.client.user_management.create_user(
@@ -176,7 +176,7 @@ def run_module():
     elif cml.params['state'] == 'absent':
         if userid is not None:
             if module.check_mode:
-                module.exit_json(changed=True)
+                cml.exit_json(changed=True)
             try:
                 cml.client.user_management.delete_user(userid)
                 cml.result['changed'] = True

--- a/plugins/modules/cml_users.py
+++ b/plugins/modules/cml_users.py
@@ -158,8 +158,9 @@ def run_module():
 
     if cml.params['state'] == 'present':
         if userid is None:
+            cml.result['changed'] = True
             if module.check_mode:
-                cml.exit_json(changed=True)
+                cml.exit_json()
             module.debug('Create user %s' % cml.params['name'])
             try:
                 cml.client.user_management.create_user(
@@ -170,16 +171,15 @@ def run_module():
                     admin=cml.params['admin'],
                     groups=cml.params['groups'],
                 )
-                cml.result['changed'] = True
             except requests.exceptions.RequestException as e:
                 cml.fail_json(name=cml.params['name'], msg=e, rc=-1)
     elif cml.params['state'] == 'absent':
         if userid is not None:
+            cml.result['changed'] = True
             if module.check_mode:
-                cml.exit_json(changed=True)
+                cml.exit_json()
             try:
                 cml.client.user_management.delete_user(userid)
-                cml.result['changed'] = True
             except requests.exceptions.RequestException as e:
                 cml.fail_json(name=cml.params['name'], msg=e, rc=-1)
 

--- a/plugins/modules/cml_users.py
+++ b/plugins/modules/cml_users.py
@@ -154,7 +154,7 @@ def run_module():
 
     if not HAS_REQUESTS:
         # Needs: from ansible.module_utils.basic import missing_required_lib
-        module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
+        cml.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
 
     if cml.params['state'] == 'present':
         if userid is None:


### PR DESCRIPTION
Provides check_mode support for both cml_lab and cml_node modules so changed status is returned without actual change happening.

Fixes issue https://github.com/CiscoDevNet/ansible-cml/issues/42