### PR TITLE
cml_node | coordinates support

### DIFF
--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -154,7 +154,24 @@ def run_module():
     if cml.params['state'] == 'present':
         if node is None:
             node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
+            # set coordinates when defined
+            if cml.params['x'] is not None:
+                node.x = cml.params['x']
+            if cml.params['y'] is not None:
+                node.y = cml.params['y']
             cml.result['changed'] = True
+        else:
+            # check coordinates of existing node when defined
+            if cml.params['x'] is not None and cml.params['x'] != node.x:
+                cml.result['changed'] = True
+                if module.check_mode:
+                    cml.exit_json()
+                node.x = cml.params['x']
+            if cml.params['y'] is not None and cml.params['y'] != node.y:
+                cml.result['changed'] = True
+                if module.check_mode:
+                    cml.exit_json()
+                node.y = cml.params['y']
     elif cml.params['state'] == 'started':
         if node is None:
             cml.fail_json("Node must be created before it is started")


### PR DESCRIPTION
Implements usage of X and Y coordinates for nodes which makes it possible to place nodes at specific coordinates or update placement of existing nodes.

The behavior implemented is only applicable for **present state** as for others it does not have a meaning.
Both below options apply for either X or Y coordinate separately:
a) if defined: make sure the node coordinate is as provided so update of coordinate will happen if its not as provided
b) if not defined: no action related to specific coordinate

In case X or Y is not defined during node creation the default is 0. When such node already exists coordinates are not checked if not defined.

Partial fix for issue: https://github.com/CiscoDevNet/ansible-cml/issues/44

### Examples:
```yaml
  - name: Create Nodes
    cisco.cml.cml_node:
      name: "{{ item.hostname }}"
      state: present
      node_definition: "{{ item.node_definition | default(omit) }}"
      x: "{{ item.x | default(omit) }}"
      y: "{{ item.y | default(omit) }}"
    loop:
      # new node
      - hostname: switch01 # new node is created and will be placed at [0,-240]
        node_definition: unmanaged_switch
        x: 0
        y: -240
      - hostname: switch02 # new node is created and will be placed at [0,-120]
        node_definition: unmanaged_switch
        y: -120
      - hostname: switch03 # new node is created and will be placed at [0,0] - same as previous behavior
        node_definition: unmanaged_switch
      # existing node
      - hostname: switch01 # node is moved from [0,-240] to [100,-120]
        x: 100
        y: -120
      - hostname: switch01 # node is moved from [100,-120] to [100,-130]
        y: -130
      - hostname: switch01 # node is moved from [100,-130] to [0,-130]
        x: 0
        y: -130
```