### PR TITLE
cml_node | add missing absent state handling

### DIFF
--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -181,6 +181,16 @@ def run_module():
         if node.state not in ['DEFINED_ON_CORE']:
             node.wipe(wait=cml.params['wait'])
             cml.result['changed'] = True
+    elif cml.params['state'] == 'absent':
+        if node is not None:
+            cml.result['changed'] = True
+            if module.check_mode:
+                cml.exit_json()
+            if node.state in ['STARTED', 'BOOTED']:
+                node.stop(wait=cml.params['wait'])
+            if node.state != 'DEFINED_ON_CORE':
+                node.wipe(wait=cml.params['wait'])
+            node.remove()
     cml.exit_json(**cml.result)
 
 


### PR DESCRIPTION
cml_node module has an absent state option which was not implemented

to make this idempotent compared to state changes (started, stopped, wiped) this state also makes sure node is stopped (if running) and wiped (if not wiped yet) before it is deleted as otherwise CML would throw an error. 
Usage of wait is preferred to make sure some delay introduced does not prevent all steps: started > stopped > wiped > removed

## Examples:
```yaml
  - name: Create 3 Nodes
    cisco.cml.cml_node:
      name: "{{ item.hostname }}"
      node_definition: unmanaged_switch
    loop:
      - hostname: switch01
      - hostname: switch02
      - hostname: switch03

  - name: Start 2 Nodes
    cisco.cml.cml_node:
      name: "{{ item.hostname }}"
      state: started
      wait: true
    loop:
      - hostname: switch01
      - hostname: switch02

  - name: Delete 3 Nodes
    cisco.cml.cml_node:
      name: "{{ item.hostname }}"
      state: absent
      wait: true
    loop:
      - hostname: switch01
      - hostname: switch02
      - hostname: switch03
```