### PR TITLE
cml_node  | making started/stopped/wiped states only changing state

### DIFF
--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -163,17 +163,13 @@ def run_module():
                 node.config = cml.params['config']
             if cml.params['image_definition']:
                 node.image_definition = cml.params['image_definition']
-            if cml.params['wait'] is False:
-                lab.wait_for_covergence = False
-            node.start()
+            node.start(wait=cml.params['wait'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'stopped':
         if node is None:
             cml.fail_json("Node must be created before it is stopped")
         if node.state not in ['STOPPED', 'DEFINED_ON_CORE']:
-            if cml.params['wait'] is False:
-                lab.wait_for_covergence = False
-            node.stop()
+            node.stop(wait=cml.params['wait'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'wiped':
         if node is None:

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -159,10 +159,6 @@ def run_module():
         if node is None:
             cml.fail_json("Node must be created before it is started")
         if node.state not in ['STARTED', 'BOOTED']:
-            if node.state == 'DEFINED_ON_CORE' and cml.params['config']:
-                node.config = cml.params['config']
-            if cml.params['image_definition']:
-                node.image_definition = cml.params['image_definition']
             node.start(wait=cml.params['wait'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'stopped':

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -170,7 +170,8 @@ def run_module():
     elif cml.params['state'] == 'wiped':
         if node is None:
             cml.fail_json("Node must be created before it is wiped")
-        if node.state not in ['DEFINED_ON_CORE']:
+            if node.state in ['STARTED', 'BOOTED']:
+                node.stop(wait=cml.params['wait'])
             node.wipe(wait=cml.params['wait'])
             cml.result['changed'] = True
     cml.exit_json(**cml.result)

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -38,7 +38,7 @@ requirements:
 version_added: '0.1.0'
 options:
     state:
-        description: The desired state of the node
+        description: The desired state of the node. Started, stopped and wiped are only state changes and require existing node.
         required: false
         type: str
         choices: ['absent', 'present', 'started', 'stopped', 'wiped']
@@ -170,6 +170,7 @@ def run_module():
     elif cml.params['state'] == 'wiped':
         if node is None:
             cml.fail_json("Node must be created before it is wiped")
+        if node.state != 'DEFINED_ON_CORE':
             if node.state in ['STARTED', 'BOOTED']:
                 node.stop(wait=cml.params['wait'])
             node.wipe(wait=cml.params['wait'])


### PR DESCRIPTION
1) I have optimized the wait to use native node methods argument wait (just cleanup)
2) I have done following changes to the behavior of state changes:

state | current behavior | new behavior | reason
--- | --- | --- | --- 
started | config and image_definition can be rewritten | node is just started, not altered | this should just start the node
stopped | N/A | N/A | no change
wiped | does fail when node is running | node will be stopped first | this way if node exist operation is idempotent and will make sure node is wiped

all 3 states will make sure the requested state is applied if node exist otherwise will return failed if node does not exist.

Absent state is currently not implemented, but part of following PR: https://github.com/CiscoDevNet/ansible-cml/pull/47

## Examples:
```yaml
  - name: Create, Start, Stop, Wipe
    cisco.cml.cml_node:
      name: "{{ item.hostname }}"
      node_definition: unmanaged_switch
      state: "{{ item.state | default(omit) }}"
    loop:
      - hostname: switch01 # created
      - hostname: switch01 # started
        state: started
      - hostname: switch01 # stopped
        state: stopped
      - hostname: switch01 # started
        state: started
      - hostname: switch01 # stopped and wiped
        state: wiped


```